### PR TITLE
Add a precheck if instance supports encrypted volumes

### DIFF
--- a/ec2cryptomatic.py
+++ b/ec2cryptomatic.py
@@ -56,8 +56,9 @@ class EC2Cryptomatic:
         self._wait_snapshot.config.delay = DELAY_RETRY
         self._wait_volume.config.delay = DELAY_RETRY
 
-        # Do some pre-check : instances must exists and be stopped
+        # Do some pre-check : instances must exists, support encrpted volumes and be stopped
         self._instance_is_exists()
+        self._instance_supports_encrypted_volume()
         self._instance_is_stopped()
 
     def _instance_is_exists(self) -> None:
@@ -70,6 +71,16 @@ class EC2Cryptomatic:
             self._ec2_client.describe_instances(InstanceIds=[self._instance.id])
         except ClientError:
             raise
+
+    def _instance_supports_encrypted_volume(self) -> None:
+        """
+        Check if instance supports encrypted volume
+        :return: None
+        :except: TypeError
+        """
+        if self._instance.instance_type.startswith(('c1.', 'm1.', 'm2.', 't1.')):
+            raise TypeError(f'Instance {self._instance.instance_type} '
+                            f'does not support encrypted volumes.')
 
     def _instance_is_stopped(self) -> None:
         """


### PR DESCRIPTION
I occurred the following error when encrypted volumes for some legacy instances

```
Start to encrypt instance i-***
- Let's encrypt volume vol-***
-- Take a snapshot for volume vol-***
-- Snapshot snap-*** done
-- Creating an encrypted volume from snap-***
-- Encrypted volume vol-*** done
-- Swap the old volume and the new one
Problem with the instance (An error occurred (EncryptedVolumesNotSupported) when calling the AttachVolume operation: 'vol-***' is encrypted and 'm1.small' does not support encrypted volumes.)
```

So added another pre-check function and run the instance type pre-check before starting encryption.

Supported instance types can be find [here](https://docs.amazonaws.cn/en_us/AWSEC2/latest/UserGuide/EBSEncryption.html#ebs-encryption-requirements).