### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -111,7 +111,7 @@ jobs:
           assets_path: artifact/
 
       - name: Publish image to Docker Hub Registry
-        uses: elgohr/Publish-Docker-Github-Action@3.01
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jbrt/ec2cryptomatic
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore